### PR TITLE
Fix code to support multiple classes for tests generation

### DIFF
--- a/src/benchmarktool/src/main/java/sbst/benchmark/RunTool.java
+++ b/src/benchmarktool/src/main/java/sbst/benchmark/RunTool.java
@@ -134,8 +134,9 @@ public class RunTool {
 				channel.emit(timeBudget);
 
 			if (generateTests) {
+				Util.cleanDirectory(testcases);
 				for (String cname : task.getClassNames()) {
-					Util.cleanDirectory(testcases);
+				
 					Main.info("\n\n### CLASS UNDER TEST ###: " + cname);
 					channel.emit(cname);
 					listener.startClass(cname);

--- a/src/runtool/src/main/java/sbst/runtool/RunTool.java
+++ b/src/runtool/src/main/java/sbst/runtool/RunTool.java
@@ -57,9 +57,10 @@ public class RunTool
 			}
 		}
 		channel.emit("READY");
+		long timeBudget = channel.longnumber();
+
 		for(int i = 0; i < m; i++)
 		{
-			long timeBudget = channel.longnumber();
 			String cName = channel.className();
 			tool.run(cName,timeBudget);
 			channel.emit("READY");


### PR DESCRIPTION
Hello, 
Thank you for the very nice infrastructure for tests generation. I have tried to generate tests at once for multiple classes and spotted a few issues. I am submitting my fix which allowed to generate tests when there are multiple classes specified in the benchmarks.list file, for example:
```
BCEL=
{
  src=/var/benchmarks/projects/bcel-6.0-src/src/main/java
  bin=/var/benchmarks/projects/bcel-6.0-src/target/classes
  classes=(
    org.apache.bcel.classfile.Utility, org.apache.bcel.verifier.structurals.InstConstraintVisitor
  )
  classpath=(
    /var/benchmarks/projects/bcel-6.0-src/target/classes
  )
}
```